### PR TITLE
Account for application of Cookiecutter template in model-training

### DIFF
--- a/src/predictor/predict.py
+++ b/src/predictor/predict.py
@@ -6,11 +6,17 @@ from lib_ml.preprocessing import preprocess_text
 class ReviewSentimentPredictor:
     def __init__(self):
         # Load trained model to generate predictions with
-        model_file = urlopen("https://github.com/remla25-team3/model-training/raw/refs/heads/main/model_training/data/sentiment_model.pkl")
+        model_file = urlopen(
+            'https://github.com/remla25-team3/model-training/raw/refs/heads/main' +
+            '/model_training/models/sentiment_model.pkl'
+        )
         self.prediction_model = joblib.load(model_file)
 
         # Sentiments model to transform string inputs into numbers
-        sentiments_file = urlopen("https://github.com/remla25-team3/model-training/raw/refs/heads/main/model_training/data/c1_BoW_Sentiment_Model.pkl")
+        sentiments_file = urlopen(
+            'https://github.com/remla25-team3/model-training/raw/refs/heads/main' +
+            '/model_training/models/bow_sentiment_model.pkl'
+        )
         self.sentiment_model = joblib.load(sentiments_file)
 
     def predict(self, user_input: str):

--- a/src/predictor/predict.py
+++ b/src/predictor/predict.py
@@ -7,15 +7,15 @@ class ReviewSentimentPredictor:
     def __init__(self):
         # Load trained model to generate predictions with
         model_file = urlopen(
-            'https://github.com/remla25-team3/model-training/raw/refs/heads/main' +
-            '/model_training/models/sentiment_model.pkl'
+            'https://raw.githubusercontent.com/remla25-team3/model-training/refs/heads/main' +
+            '/models/sentiment_model.pkl'
         )
         self.prediction_model = joblib.load(model_file)
 
         # Sentiments model to transform string inputs into numbers
         sentiments_file = urlopen(
-            'https://github.com/remla25-team3/model-training/raw/refs/heads/main' +
-            '/model_training/models/bow_sentiment_model.pkl'
+            'https://raw.githubusercontent.com/remla25-team3/model-training/refs/heads/main' +
+            '/models/bow_sentiment_model.pkl'
         )
         self.sentiment_model = joblib.load(sentiments_file)
 
@@ -34,10 +34,10 @@ class ReviewSentimentPredictor:
         if user_input == '':
             raise ValueError('Input should not be empty')
 
-        preprocessed = [preprocess_text(user_input)]
+        preprocessed = [preprocess_text(user_input)] # Apply lib-ml preprocessing
         transformed = self.sentiment_model.transform(preprocessed).toarray()
-        X = np.array(transformed, dtype=object).reshape(1, -1) # Apply lib-ml preprocessing
-        predictions = self.prediction_model.predict(X)
+        x = np.array(transformed, dtype=object).reshape(1, -1)
+        predictions = self.prediction_model.predict(x)
 
         if len(predictions) == 0:
             raise Exception('Error generating prediction')


### PR DESCRIPTION
The model URLs in `model-training` have changed as a result of applying the Cookiecutter template. The URLs have been fixed here.

### Note

~~The unit test action fails because the service is currently looking for the models in the wrong place. This will automatically be fixed when https://github.com/remla25-team3/model-training/pull/3 is pulled.~~  *This is now done and the automatic tests pass.*